### PR TITLE
Refactor the reporter a bit and make it grok skipped lines.

### DIFF
--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -170,7 +170,7 @@ class SimpleCov::Formatter::Codecov
   # @return [Hash<String, Array<nil, Integer>>]
   def result_to_codecov(result)
     result.files.inject({}) do |memo, file|
-      memo[file.filename] = file_to_codecov(file)
+      memo[shortened_filename(file)] = file_to_codecov(file)
       memo
     end
   end
@@ -188,5 +188,14 @@ class SimpleCov::Formatter::Codecov
         line.coverage
       end
     end
+  end
+
+  # Get a filename relative to the project root. Based on
+  # https://github.com/colszowka/simplecov-html, copyright Christoph Olszowka.
+  #
+  # @param file [SimeplCov::SourceFile] The file to use.
+  # @return [String]
+  def shortened_filename(file)
+    file.filename.gsub(SimpleCov.root, '.').gsub(/^\.\//, '')
   end
 end

--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -170,9 +170,7 @@ class SimpleCov::Formatter::Codecov
   # @return [Hash<String, Array<nil, Integer>>]
   def result_to_codecov(result)
     result.files.inject({}) do |memo, file|
-      if result.filenames.include?(file.filename)
-        memo[file.filename] = file_to_codecov(file)
-      end
+      memo[file.filename] = file_to_codecov(file)
       memo
     end
   end

--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -3,7 +3,7 @@ require 'json'
 require 'net/http'
 
 class SimpleCov::Formatter::Codecov
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
   def format(result)
     # =================
     # Build JSON Report


### PR DESCRIPTION
So this should be a bit better than what was there but it is having some odd results for me. I tried it out on https://codecov.io/github/poise/poise-service?ref=master and it seems to be showing the full paths as reported by SimpleCov. Maybe this is usually fixed up on the server side for Travis builds?