### PR TITLE
#6: fool-proof net blockers

### DIFF
--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -270,14 +270,15 @@ class SimpleCov::Formatter::Codecov
     end
 
     if defined?(WebMock)
-      @webmock_enabled ||= WebMock::HttpLibAdapters::HttpGemAdapter.enabled?
+      # WebMock on by default
+      # VCR depends on WebMock 1.8.11; no method to check whether enabled.
       action = case switch
       when :on
         'disable'
       when :off
         'allow'
       end
-      WebMock.send "#{action}_net_connect!".to_sym if @webmock_enabled
+      WebMock.send "#{action}_net_connect!".to_sym
     end
 
     return true


### PR DESCRIPTION
Resolves #6 

__Background__
Unable to upload report to CodeCov when using Codeship CI
App has VCR and WebMock enabled

__Cause__
VCR and WebMock were not being properly disabled

__Solution__
Disable VCR and WebMock before report upload request
Return to default state after report upload request