### PR TITLE
Use minitest instead of test unit in order to gain compatibility with ruby 1.9+

### DIFF
--- a/codecov.gemspec
+++ b/codecov.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "mocha"
   s.add_development_dependency "rake"
+  s.add_development_dependency "minitest"
 
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -10,8 +10,5 @@ if ENV['CI'] == 'true'
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'mocha/setup'
-
-class Test::Unit::TestCase
-end

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -1,7 +1,7 @@
 require 'helper'
 
 
-class TestCodecov < Test::Unit::TestCase
+class TestCodecov < Minitest::Test
   REALENV = {
     "TRAVIS_BRANCH" => ENV["TRAVIS_BRANCH"],
     "TRAVIS_COMMIT" => ENV["TRAVIS_COMMIT"],
@@ -9,7 +9,6 @@ class TestCodecov < Test::Unit::TestCase
     "TRAVIS_JOB_NUMBER" => ENV['TRAVIS_JOB_NUMBER'],
     "TRAVIS_PULL_REQUEST" => ENV["TRAVIS_PULL_REQUEST"],
     "TRAVIS_JOB_ID" => ENV["TRAVIS_JOB_ID"],
-    "TRAVIS_REPO_SLUG" => ENV["TRAVIS_REPO_SLUG"],
   }
   def url
     return ENV['CODECOV_URL'] || "https://codecov.io"


### PR DESCRIPTION
This will get the tests passing on ruby 1.9+ and is still compatible with 1.8.7.

