### PR TITLE
Fix issue with shortened filenames when Simplecov.root is a substring

### DIFF
--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -268,7 +268,7 @@ class SimpleCov::Formatter::Codecov
   # @param file [SimeplCov::SourceFile] The file to use.
   # @return [String]
   def shortened_filename(file)
-    file.filename.gsub(SimpleCov.root, '.').gsub(/^\.\//, '')
+    file.filename.gsub(/^#{SimpleCov.root}/, '.').gsub(/^\.\//, '')
   end
 
 

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -372,4 +372,18 @@ class TestCodecov < Minitest::Test
     assert_equal("owner/repo", result['params'][:slug])
     assert_equal('473c8c5b-10ee-4d83-86c6-bfd72a185a27', result['params']['token'])
   end
+
+  def test_filenames_are_shortened_correctly
+    formatter = SimpleCov::Formatter::Codecov.new
+    result = stub('SimpleCov::Result', files: [
+      stub_file('/path/lib/something.rb', []),
+      stub_file('/path/path/lib/path_somefile.rb', []),
+    ])
+    SimpleCov.stubs(:root).returns('/path')
+    data = formatter.format(result)
+    assert_equal(data['coverage'].to_json, {
+      'lib/something.rb' => [nil],
+      'path/lib/path_somefile.rb' => [nil]
+    }.to_json)
+  end
 end


### PR DESCRIPTION
If `SimpleCov.root` happens to be contained more than once in a file path, all occurrences will be removed by `shortened_filename`.

For example, the path when `SimpleCov.root` is `/app`:
`app/app/controllers/application_controller.rb` will be shortened to `../controllers/.lication_controller.rb`

To fix this, I use a regex to only substitute the root at the start of a file path.

@stevepeak 