### PR TITLE
Ignoring cassettes when turning off VCR

### DIFF
--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -298,8 +298,12 @@ class SimpleCov::Formatter::Codecov
     throw 'Only :on or :off' unless [:on, :off].include? switch
 
     if defined?(VCR)
-      @vcr_enabled ||= VCR.turned_on?
-      VCR.send "turn_#{switch}!".to_sym if @vcr_enabled
+      case switch
+      when :on
+        VCR.turn_on!
+      when :off
+        VCR.turn_off!(:ignore_cassettes => true)
+      end
     end
 
     if defined?(WebMock)


### PR DESCRIPTION
Current VCR patch did not work for me. Codeship complained with:

```
`insert_cassette': VCR is turned off.  You must turn it on before you can insert a cassette.  Or you can use the `:ignore_cassettes => true` option to completely ignore cassette insertions. (VCR::Errors::TurnedOffError)
```

This patch worked for me, but I'm not sure if it can have any other implications for different setups. 