### PR TITLE
Add Buildkite to the list of supported CI companies

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ end
 ```
 
 ### CI Companies Supported
-Jenkins, Travis CI, Codeship, Circle CI, Semaphore, drone.io, AppVeyor, Wercker, Magnum, Shippable, and Gitlab CI. Otherwise fallbacks on `git`.
+Jenkins, Travis CI, Codeship, Circle CI, Semaphore, drone.io, AppVeyor, Wercker, Magnum, Shippable, Gitlab CI, and Buildkite. Otherwise fallbacks on `git`.
 
 ### Caveat
 


### PR DESCRIPTION
The most recent version added Buildkite support, but they don't appear in the list of supported companies.