### PR TITLE
Preserve webmock config when toggling it around report

### DIFF
--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -309,13 +309,12 @@ class SimpleCov::Formatter::Codecov
     if defined?(WebMock)
       # WebMock on by default
       # VCR depends on WebMock 1.8.11; no method to check whether enabled.
-      action = case switch
+      case switch
       when :on
-        'disable'
+        WebMock.enable!
       when :off
-        'allow'
+        WebMock.disable!
       end
-      WebMock.send "#{action}_net_connect!".to_sym
     end
 
     return true


### PR DESCRIPTION
Using `{enable,disable}_net_connect!` resets existing config instead of
toggling behavior.
See https://github.com/bblimke/webmock/blob/master/lib/webmock/webmock.rb#L49
