### PR TITLE
Fix GitLab CI detection

### DIFF
--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -161,7 +161,7 @@ class SimpleCov::Formatter::Codecov
 
     # GitLab CI
     # ---------
-    elsif ENV['CI_SERVER_NAME'] == 'GitLab CI'
+    elsif ENV.key?('GITLAB_CI')
         # http://doc.gitlab.com/ci/examples/README.html#environmental-variables
         # https://gitlab.com/gitlab-org/gitlab-ci-runner/blob/master/lib/build.rb#L96
         params[:service] = 'gitlab'

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -360,7 +360,7 @@ class TestCodecov < Minitest::Test
     assert_equal('f881216b-b5c0-4eb1-8f21-b51887d1d506', result['params']['token'])
   end
   def test_gitlab
-    ENV['CI_SERVER_NAME'] = "GitLab CI"
+    ENV['GITLAB_CI'] = "true"
     ENV['CI_BUILD_REF_NAME'] = "master"
     ENV['CI_BUILD_ID'] = "1"
     ENV['CI_BUILD_REPO'] = "https://gitlab.com/owner/repo.git"


### PR DESCRIPTION
Check for presence of `GITLAB_CI` environment variable, instead of the value of `CI_SERVER_NAME` variable, which doesn't seem to work as intended.

See also https://github.com/codecov/codecov-node/pull/37/files