### PR TITLE
Add license to gemspec

### DIFF
--- a/codecov.gemspec
+++ b/codecov.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.homepage           = %q{https://github.com/codecov/codecov-ruby}
   s.summary            = %q{hosted code coverage ruby/rails reporter}
   s.rubyforge_project  = "codecov"
+  s.license            = "MIT"
   s.files              = ["lib/codecov.rb"]
   s.test_files         = ["test/test_codecov.rb"]
   s.require_paths      = ["lib"]

--- a/codecov.gemspec
+++ b/codecov.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name               = "codecov"
-  s.version            = "0.1.10"
+  s.version            = "0.1.11"
   s.platform           = Gem::Platform::RUBY
   s.authors            = ["codecov"]
   s.email              = ["hello@codecov.io"]

--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -3,7 +3,7 @@ require 'json'
 require 'net/http'
 
 class SimpleCov::Formatter::Codecov
-  VERSION = "0.1.10"
+  VERSION = "0.1.11"
   def format(result)
     net_blockers(:off)
 


### PR DESCRIPTION
Noticed your gem doesn't have the license specified in the gemspec when I was auditing it for inclusion in one of my apps.