### PR TITLE
Fix builds in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,8 @@ rvm:
   - 2.0.0
   - 2.1
   - jruby
+  - rbx-3
   - rbx-2
+matrix:
+  allow_failures:
+    - rvm: rbx-2

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -108,6 +108,7 @@ class TestCodecov < Minitest::Test
     ENV['ghprbActualCommit'] = nil
     ENV['ghprbPullId'] = nil
     ENV['ghprbSourceBranch'] = nil
+    ENV['GITLAB_CI'] = nil
     ENV['GIT_BRANCH'] = nil
     ENV['GIT_COMMIT'] = nil
     ENV['JENKINS_URL'] = nil


### PR DESCRIPTION
Fix builds to be green.

1. Fix missing nullify in teardown
2. Modify .travis.yml