### PR TITLE
Add Azure Pipelines support

### DIFF
--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -200,6 +200,18 @@ class SimpleCov::Formatter::Codecov
       params[:build_url] = ENV['TEAMCITY_BUILD_URL']
       params[:commit] = ENV['TEAMCITY_BUILD_COMMIT']
       params[:slug] = ENV['TEAMCITY_BUILD_REPOSITORY'].split('/', 4)[-1].sub('.git', '')
+
+    # Azure Pipelines
+    # ---------
+    elsif ENV['TF_BUILD'] != nil
+      params[:service] = 'azure_pipelines'
+      params[:branch] = ENV['BUILD_SOURCEBRANCH']
+      params[:pull_request] = ENV['SYSTEM_PULLREQUEST_PULLREQUESTNUMBER']
+      params[:job] = ENV['SYSTEM_JOBID']
+      params[:build] = ENV['BUILD_BUILDID']
+      params[:build_url] = "#{ENV['SYSTEM_TEAMFOUNDATIONSERVERURI']}/#{ENV['SYSTEM_TEAMPROJECT']}/_build/results?buildId=#{ENV['BUILD_BUILDID']}"
+      params[:commit] = ENV['BUILD_SOURCEVERSION']
+      params[:slug] = ENV['BUILD_REPOSITORY_ID']
     end
 
     if params[:branch] == nil

--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -180,7 +180,8 @@ class SimpleCov::Formatter::Codecov
       params[:service] = 'gitlab'
       params[:branch] = ENV['CI_BUILD_REF_NAME'] || ENV['CI_COMMIT_REF_NAME']
       params[:build] = ENV['CI_BUILD_ID'] || ENV['CI_JOB_ID']
-      params[:slug] = (ENV['CI_BUILD_REPO'] || ENV['CI_REPOSITORY_URL']).split('/', 4)[-1].sub('.git', '')
+      slug = ENV['CI_BUILD_REPO'] || ENV['CI_REPOSITORY_URL']
+      params[:slug] = slug.split('/', 4)[-1].sub('.git', '') if slug
       params[:commit] = ENV['CI_BUILD_REF'] || ENV['CI_COMMIT_SHA']
 
     # Teamcity

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -110,6 +110,7 @@ class TestCodecov < Minitest::Test
     ENV['ghprbSourceBranch'] = nil
     ENV['GIT_BRANCH'] = nil
     ENV['GIT_COMMIT'] = nil
+    ENV['GITLAB_CI'] = nil
     ENV['JENKINS_URL'] = nil
     ENV['MAGNUM'] = nil
     ENV['PULL_REQUEST'] = nil

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -378,6 +378,22 @@ class TestCodecov < Minitest::Test
     assert_equal("owner/repo", result['params'][:slug])
     assert_equal('f881216b-b5c0-4eb1-8f21-b51887d1d506', result['params']['token'])
   end
+  def test_teamcity
+    ENV['CI_SERVER_NAME'] = "TeamCity"
+    ENV['TEAMCITY_BUILD_BRANCH'] = "master"
+    ENV['TEAMCITY_BUILD_ID'] = "1"
+    ENV['TEAMCITY_BUILD_URL'] = 'http://teamcity/...'
+    ENV['TEAMCITY_BUILD_COMMIT'] = "743b04806ea677403aa2ff26c6bdeb85005de658"
+    ENV['TEAMCITY_BUILD_REPOSITORY'] = "https://github.com/owner/repo.git"
+    ENV['CODECOV_TOKEN'] = 'f881216b-b5c0-4eb1-8f21-b51887d1d506'
+    result = upload
+    assert_equal("teamcity", result['params'][:service])
+    assert_equal("743b04806ea677403aa2ff26c6bdeb85005de658", result['params'][:commit])
+    assert_equal("1", result['params'][:build])
+    assert_equal("master", result['params'][:branch])
+    assert_equal("owner/repo", result['params'][:slug])
+    assert_equal('f881216b-b5c0-4eb1-8f21-b51887d1d506', result['params']['token'])
+  end
   def test_azure_pipelines
     ENV['TF_BUILD'] = "1"
     ENV['BUILD_SOURCEBRANCH'] = "master"

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -127,6 +127,7 @@ class TestCodecov < Minitest::Test
     ENV['SNAP_PULL_REQUEST_NUMBER'] = nil
     ENV['SNAP_UPSTREAM_BRANCH'] = nil
     ENV['SNAP_UPSTREAM_COMMIT'] = nil
+    ENV['TF_BUILD'] = nil
     ENV['TRAVIS'] = "true"
     ENV['TRAVIS_BRANCH'] = REALENV["TRAVIS_BRANCH"]
     ENV['TRAVIS_COMMIT'] = REALENV["TRAVIS_COMMIT"]
@@ -371,6 +372,24 @@ class TestCodecov < Minitest::Test
     ENV['CODECOV_TOKEN'] = 'f881216b-b5c0-4eb1-8f21-b51887d1d506'
     result = upload
     assert_equal("gitlab", result['params'][:service])
+    assert_equal("743b04806ea677403aa2ff26c6bdeb85005de658", result['params'][:commit])
+    assert_equal("1", result['params'][:build])
+    assert_equal("master", result['params'][:branch])
+    assert_equal("owner/repo", result['params'][:slug])
+    assert_equal('f881216b-b5c0-4eb1-8f21-b51887d1d506', result['params']['token'])
+  end
+  def test_azure_pipelines
+    ENV['TF_BUILD'] = "1"
+    ENV['BUILD_SOURCEBRANCH'] = "master"
+    ENV['SYSTEM_JOBID'] = '92a2fa25-f940-5df6-a185-81eb9ae2031d'
+    ENV['BUILD_BUILDID'] = "1"
+    ENV['SYSTEM_TEAMFOUNDATIONSERVERURI'] = 'https://dev.azure.com/codecov/'
+    ENV['SYSTEM_TEAMPROJECT'] = 'repo'
+    ENV['BUILD_SOURCEVERSION'] = "743b04806ea677403aa2ff26c6bdeb85005de658"
+    ENV['BUILD_REPOSITORY_ID'] = 'owner/repo'
+    ENV['CODECOV_TOKEN'] = 'f881216b-b5c0-4eb1-8f21-b51887d1d506'
+    result = upload
+    assert_equal("azure_pipelines", result['params'][:service])
     assert_equal("743b04806ea677403aa2ff26c6bdeb85005de658", result['params'][:commit])
     assert_equal("1", result['params'][:build])
     assert_equal("master", result['params'][:branch])


### PR DESCRIPTION
I'm trying to use [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) for Homebrew's CI and CodeCov is the last thing blocking us moving over.

Also, while I was doing local testing I came across a few test bugs that I've fixed here too (and a missing test for TeamCity).

CC @stevepeak 