### PR TITLE
Print a summary message similar to the default HTMLFormatter

### DIFF
--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -285,9 +285,17 @@ class SimpleCov::Formatter::Codecov
       puts err
     end
 
+    puts output_message(result)
   end
 
-  private
+  # A message similar to the final line printed by the default SimpleCov::Formatter::HTMLFormatter.
+  # Adapted from https://github.com/colszowka/simplecov-html/blob/9ec41504ab139fabfaddfc786dfdab5d6aca0bab/lib/simplecov-html.rb#L28.
+  #
+  # @param result [SimpleCov::Result] The coverage data to process.
+  # @return [String]
+  def output_message(result)
+    "Coverage report generated for #{result.command_name}. #{result.covered_lines} / #{result.total_lines} LOC (#{result.covered_percent.round(2)}%) covered."
+  end
 
   # Format SimpleCov coverage data for the Codecov.io API.
   #


### PR DESCRIPTION
GitLab can capture the coverage of a job using a regular expression (https://docs.gitlab.com/ee/user/project/pipelines/settings.html#test-coverage-parsing) and includes an example regular expression for Ruby projects using SimpleCov:

> Below are examples of regex for existing tools:
>
> - Simplecov (Ruby) - \(\d+.\d+\%\) covered

This is based on the default `SimpleCov::Formatter::HTMLFormatter` output:

```
Coverage report generated for RSpec to ./coverage. 156 / 204 LOC (76.47%) covered.
```

However, this no longer works because the Codecov formatter doesn't print out such a summary. This PR just adapts the code from the HTMLFormatter to print out a similar message which can be picked up by GitLab with the same regular expression.

Example output:

```
...
{"uploaded": true, "url": "https://codecov.io/...", "queued": true, "meta": {"status": 200}, "message": "Coverage reports upload successfully", "id": "..."}
Coverage report generated for RSpec. 156 / 204 LOC (76.47%) covered.
```