### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/codecov.gemspec
+++ b/codecov.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |s|
   s.description        = %q{hosted code coverage}
   s.homepage           = %q{https://github.com/codecov/codecov-ruby}
   s.summary            = %q{hosted code coverage ruby/rails reporter}
-  s.rubyforge_project  = "codecov"
   s.license            = "MIT"
   s.files              = ["lib/codecov.rb"]
   s.test_files         = ["test/test_codecov.rb"]


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement.