### PR TITLE
Adding support for BitBucket pipelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ rvm:
 matrix:
   allow_failures:
     - rvm: rbx-2
+    - rvm: rbx-3

--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -215,6 +215,14 @@ class SimpleCov::Formatter::Codecov
       params[:commit] = ENV['BUILD_SOURCEVERSION']
       params[:slug] = ENV['BUILD_REPOSITORY_ID']
 
+    elsif ENV['CI'] == 'true' and ENV['BITBUCKET_BRANCH'] != nil
+      # https://confluence.atlassian.com/bitbucket/variables-in-pipelines-794502608.html
+      params[:service] = 'bitbucket'
+      params[:branch] = ENV['BITBUCKET_BRANCH']
+      # BITBUCKET_COMMIT does not always provide full commit sha due to a bug https://jira.atlassian.com/browse/BCLOUD-19393#
+      params[:commit] = (ENV['BITBUCKET_COMMIT'].length < 40 ? nil : ENV['BITBUCKET_COMMIT'])
+      params[:build] = ENV['BITBUCKET_BUILD_NUMBER']
+
     # Heroku CI
     # ---------
     elsif ENV['HEROKU_TEST_RUN_ID']
@@ -230,7 +238,10 @@ class SimpleCov::Formatter::Codecov
         params[:branch] = branch != 'HEAD' ? branch : 'master'
     end
 
-    if params[:commit] == nil
+    if ENV["VCS_COMMIT_ID"] != nil
+      params[:commit] = ENV["VCS_COMMIT_ID"]
+
+    elsif params[:commit] == nil
         params[:commit] = `git rev-parse HEAD`.strip
     end
 

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -61,6 +61,9 @@ class TestCodecov < Minitest::Test
     ENV['APPVEYOR_REPO_BRANCH'] = nil
     ENV['APPVEYOR_REPO_COMMIT'] = nil
     ENV['APPVEYOR_REPO_NAME'] = nil
+    ENV['BITBUCKET_BRANCH'] = nil
+    ENV['BITBUCKET_BUILD_NUMBER'] = nil
+    ENV['BITBUCKET_COMMIT'] = nil
     ENV['BITRISE_BUILD_NUMBER'] = nil
     ENV['BITRISE_BUILD_URL'] = nil
     ENV['BITRISE_GIT_BRANCH'] = nil
@@ -140,12 +143,14 @@ class TestCodecov < Minitest::Test
     ENV['TRAVIS_JOB_NUMBER'] = REALENV["TRAVIS_JOB_NUMBER"]
     ENV['TRAVIS_PULL_REQUEST'] = REALENV["TRAVIS_PULL_REQUEST"]
     ENV['TRAVIS_REPO_SLUG'] = REALENV["TRAVIS_REPO_SLUG"]
+    ENV['VCS_COMMIT_ID'] = nil
     ENV['WERCKER_GIT_BRANCH'] = nil
     ENV['WERCKER_GIT_COMMIT'] = nil
     ENV['WERCKER_GIT_OWNER'] = nil
     ENV['WERCKER_GIT_REPOSITORY'] = nil
     ENV['WERCKER_MAIN_PIPELINE_STARTED'] = nil
     ENV['WORKSPACE'] = nil
+    ENV
   end
   def test_git
     ENV['CODECOV_TOKEN'] = 'f881216b-b5c0-4eb1-8f21-b51887d1d506'
@@ -435,6 +440,35 @@ class TestCodecov < Minitest::Test
     assert_equal("heroku", result['params'][:service])
     assert_equal("743b04806ea677403aa2ff26c6bdeb85005de658", result['params'][:commit])
     assert_equal("454f5dc9-afa4-433f-bb28-84678a00fd98", result['params'][:build])
+    assert_equal("master", result['params'][:branch])
+    assert_equal('f881216b-b5c0-4eb1-8f21-b51887d1d506', result['params']['token'])
+  end
+  def test_bitbucket_pr
+    ENV['CI'] = 'true'
+    ENV['BITBUCKET_BUILD_NUMBER'] = "100"
+    ENV['BITBUCKET_BRANCH'] = "master"
+    ENV['BITBUCKET_COMMIT'] = "743b04806ea67"
+    ENV['VCS_COMMIT_ID'] = '743b04806ea677403aa2ff26c6bdeb85005de658'
+    ENV['CODECOV_TOKEN'] = 'f881216b-b5c0-4eb1-8f21-b51887d1d506'
+
+    result = upload
+    assert_equal("bitbucket", result['params'][:service])
+    assert_equal("743b04806ea677403aa2ff26c6bdeb85005de658", result['params'][:commit])
+    assert_equal("100", result['params'][:build])
+    assert_equal("master", result['params'][:branch])
+    assert_equal('f881216b-b5c0-4eb1-8f21-b51887d1d506', result['params']['token'])
+  end
+  def test_bitbucket
+    ENV['CI'] = 'true'
+    ENV['BITBUCKET_BUILD_NUMBER'] = "100"
+    ENV['BITBUCKET_BRANCH'] = "master"
+    ENV['BITBUCKET_COMMIT'] = "743b04806ea677403aa2ff26c6bdeb85005de658"
+    ENV['CODECOV_TOKEN'] = 'f881216b-b5c0-4eb1-8f21-b51887d1d506'
+
+    result = upload
+    assert_equal("bitbucket", result['params'][:service])
+    assert_equal("743b04806ea677403aa2ff26c6bdeb85005de658", result['params'][:commit])
+    assert_equal("100", result['params'][:build])
     assert_equal("master", result['params'][:branch])
     assert_equal('f881216b-b5c0-4eb1-8f21-b51887d1d506', result['params']['token'])
   end

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -150,7 +150,6 @@ class TestCodecov < Minitest::Test
     ENV['WERCKER_GIT_REPOSITORY'] = nil
     ENV['WERCKER_MAIN_PIPELINE_STARTED'] = nil
     ENV['WORKSPACE'] = nil
-    ENV
   end
   def test_git
     ENV['CODECOV_TOKEN'] = 'f881216b-b5c0-4eb1-8f21-b51887d1d506'


### PR DESCRIPTION
I have added support to detect when running in BitBucket pipelines.

Note: I needed to add override to the commit sha to detect env var VCS_COMMIT_ID, this is because of this bitbucket pipelines bug https://jira.atlassian.com/browse/BCLOUD-19393#