### PR TITLE
Require simplecov before defining SimpleCov namespaced class

### DIFF
--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -4,7 +4,7 @@ require 'net/http'
 require 'simplecov'
 
 class SimpleCov::Formatter::Codecov
-  VERSION = "0.1.15"
+  VERSION = "0.1.16"
   def format(result)
     net_blockers(:off)
 

--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -1,6 +1,7 @@
 require 'uri'
 require 'json'
 require 'net/http'
+require 'simplecov'
 
 class SimpleCov::Formatter::Codecov
   VERSION = "0.1.15"


### PR DESCRIPTION
It prevents `NameError: uninitialized constant SimpleCov`