### PR TITLE
Use pull request commit HEAD for Travis if available

### DIFF
--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -38,7 +38,10 @@ class SimpleCov::Formatter::Codecov
         params[:job] = ENV['TRAVIS_JOB_ID']
         params[:slug] = ENV['TRAVIS_REPO_SLUG']
         params[:build] = ENV['TRAVIS_JOB_NUMBER']
-        params[:commit] = ENV['TRAVIS_COMMIT']
+        params[:commit] = ENV['TRAVIS_PULL_REQUEST_SHA']
+        if params[:commit].to_s.empty?
+          params[:commit] = ENV['TRAVIS_COMMIT']
+        end
         params[:env] = ENV['TRAVIS_RUBY_VERSION']
 
     # Codeship

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -8,6 +8,7 @@ class TestCodecov < Minitest::Test
     "TRAVIS_REPO_SLUG" => ENV['TRAVIS_REPO_SLUG'],
     "TRAVIS_JOB_NUMBER" => ENV['TRAVIS_JOB_NUMBER'],
     "TRAVIS_PULL_REQUEST" => ENV["TRAVIS_PULL_REQUEST"],
+    "TRAVIS_PULL_REQUEST_SHA" => ENV["TRAVIS_PULL_REQUEST_SHA"],
     "TRAVIS_JOB_ID" => ENV["TRAVIS_JOB_ID"],
   }
   def url
@@ -142,6 +143,7 @@ class TestCodecov < Minitest::Test
     ENV['TRAVIS_JOB_ID'] = REALENV["TRAVIS_JOB_ID"]
     ENV['TRAVIS_JOB_NUMBER'] = REALENV["TRAVIS_JOB_NUMBER"]
     ENV['TRAVIS_PULL_REQUEST'] = REALENV["TRAVIS_PULL_REQUEST"]
+    ENV['TRAVIS_PULL_REQUEST_SHA'] = REALENV["TRAVIS_PULL_REQUEST_SHA"]
     ENV['TRAVIS_REPO_SLUG'] = REALENV["TRAVIS_REPO_SLUG"]
     ENV['VCS_COMMIT_ID'] = nil
     ENV['WERCKER_GIT_BRANCH'] = nil
@@ -166,6 +168,7 @@ class TestCodecov < Minitest::Test
     ENV['TRAVIS_COMMIT'] = "c739768fcac68144a3a6d82305b9c4106934d31a"
     ENV['TRAVIS_JOB_ID'] = "33116958"
     ENV['TRAVIS_PULL_REQUEST'] = "false"
+    ENV['TRAVIS_PULL_REQUEST_SHA'] = ""
     ENV['TRAVIS_JOB_NUMBER'] = "1"
     ENV['TRAVIS_REPO_SLUG'] = "codecov/ci-repo"
     ENV['CODECOV_TOKEN'] = 'f881216b-b5c0-4eb1-8f21-b51887d1d506'
@@ -176,6 +179,26 @@ class TestCodecov < Minitest::Test
     assert_equal("1", result['params'][:build])
     assert_equal("33116958", result['params'][:job])
     assert_equal('false', result['params'][:pull_request])
+    assert_equal('f881216b-b5c0-4eb1-8f21-b51887d1d506', result['params']['token'])
+  end
+  def test_travis_pr
+    ENV['CI'] = 'true'
+    ENV['TRAVIS'] = "true"
+    ENV['TRAVIS_BRANCH'] = "master"
+    ENV['TRAVIS_COMMIT'] = "c739768fcac68144a3a6d82305b9c4106934d31a"
+    ENV['TRAVIS_JOB_ID'] = "33116958"
+    ENV['TRAVIS_PULL_REQUEST'] = "16"
+    ENV['TRAVIS_PULL_REQUEST_SHA'] = "d5e7f1e40142d40463f1374c5e1bb4301b5f709c"
+    ENV['TRAVIS_JOB_NUMBER'] = "1"
+    ENV['TRAVIS_REPO_SLUG'] = "codecov/ci-repo"
+    ENV['CODECOV_TOKEN'] = 'f881216b-b5c0-4eb1-8f21-b51887d1d506'
+    result = upload
+    assert_equal("travis", result['params'][:service])
+    assert_equal("d5e7f1e40142d40463f1374c5e1bb4301b5f709c", result['params'][:commit])
+    assert_equal("codecov/ci-repo", result['params'][:slug])
+    assert_equal("1", result['params'][:build])
+    assert_equal("33116958", result['params'][:job])
+    assert_equal('16', result['params'][:pull_request])
     assert_equal('f881216b-b5c0-4eb1-8f21-b51887d1d506', result['params']['token'])
   end
   def test_codeship


### PR DESCRIPTION
From [Travis docs](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables):
> `TRAVIS_PULL_REQUEST_SHA`:
> - if the current job is a pull request, the commit SHA of the HEAD commit of the PR.
> - if the current job is a push build, this variable is empty ("").

Using this variable will prevent coverage numbers of pull requests from interfering with coverage numbers on the destination branch, similar to how the bash client behaves:

https://github.com/codecov/codecov-bash/commit/abed6cd23a38bc323670d1c3f11b8f00526d7b6b