### PR TITLE
account for parallel testing

### DIFF
--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -6,6 +6,8 @@ require 'simplecov'
 class SimpleCov::Formatter::Codecov
   VERSION = "0.1.16"
   def format(result)
+    return result if ENV['TEST_ENV_NUMBER'] || (defined?(ParallelTests) && ParallelTests.number_of_running_processes > 1)
+
     net_blockers(:off)
 
     # =================

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -485,4 +485,16 @@ class TestCodecov < Minitest::Test
       'path/lib/path_somefile.rb' => [nil]
     }.to_json)
   end
+
+  INVALID_FORMAT_ARGUMENT = 'would-otherwise-fail'
+
+  def test_do_nothing_for_parallel_test_env
+    formatter = SimpleCov::Formatter::Codecov.new
+    ENV['TEST_ENV_NUMBER'] = '1'
+    assert_equal(formatter.format(INVALID_FORMAT_ARGUMENT), INVALID_FORMAT_ARGUMENT)
+  ensure
+    ENV['TEST_ENV_NUMBER'] = nil
+  end
+
+  # TODO - write tests for other ParallelTests behavior -- don't want to expand the testing gem footprint w/o consensus...
 end


### PR DESCRIPTION
- if parallel test ENV or more than 1 process, do nothing
- add test for ENV case
- could testing for other scenarios would require significant increase in test gem surface area

NOTE: i patterned my change after the code in SimpleCov that checks for parallel tests before finalizing coverage itself (see [simplecov gist](https://github.com/colszowka/simplecov/blob/master/lib/simplecov.rb#L268))