### PR TITLE
Update to not end-of-life Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,7 @@ notifications:
 script:
   - bundle exec rake
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1
+  - 2.5
+  - 2.6
+  - 2.7
   - jruby
-  - rbx-3
-  - rbx-2
-matrix:
-  allow_failures:
-    - rvm: rbx-2
-    - rvm: rbx-3

--- a/codecov.gemspec
+++ b/codecov.gemspec
@@ -15,12 +15,13 @@ Gem::Specification.new do |s|
   s.test_files         = ["test/test_codecov.rb"]
   s.require_paths      = ["lib"]
 
-  s.add_dependency "url"
   s.add_dependency "json"
   s.add_dependency "simplecov"
+  s.add_dependency "url"
 
+  s.add_development_dependency "minitest"
   s.add_development_dependency "mocha"
   s.add_development_dependency "rake"
-  s.add_development_dependency "minitest"
+  s.add_development_dependency "rubocop"
 
 end

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -410,8 +410,6 @@ class TestCodecov < Minitest::Test
     assert_equal('f881216b-b5c0-4eb1-8f21-b51887d1d506', result['params']['token'])
   end
   def test_azure_pipelines
-    skip "azure_pipelines is not recognized as a CI provider by codecov now"
-
     ENV['TF_BUILD'] = "1"
     ENV['BUILD_SOURCEBRANCH'] = "master"
     ENV['SYSTEM_JOBID'] = '92a2fa25-f940-5df6-a185-81eb9ae2031d'


### PR DESCRIPTION
Everything below 2.5 is EOL (https://www.ruby-lang.org/en/downloads/branches/). This may explain the test breakages