### PR TITLE
Use `Timeout::Error` instead of deprecated `TimeoutError`

### DIFF
--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -273,7 +273,7 @@ class SimpleCov::Formatter::Codecov
     retries = 3
     begin
       response = https.request(req)
-    rescue TimeoutError => e
+    rescue Timeout::Error => e
       retries -= 1
 
       if retries.zero?


### PR DESCRIPTION
`TimeoutError` was deprecated in Ruby 2.3.
Ref: https://github.com/ruby/timeout/commit/14ba13f9e31f8e960d84a50717752248221c3cc1