### PR TITLE
Add support GitHub Actions

### DIFF
--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -20,6 +20,7 @@ class SimpleCov::Formatter::Codecov
     CIRCLE = 'Circle CI',
     CODESHIP = 'Codeship CI',
     DRONEIO = 'Drone CI',
+    GITHUB = 'GitHub Actions',
     GITLAB = 'GitLab CI',
     HEROKU = 'Heroku CI',
     JENKINS = 'Jenkins CI',
@@ -62,6 +63,8 @@ class SimpleCov::Formatter::Codecov
            CODESHIP
          elsif ((ENV['CI'] == 'true') || (ENV['CI'] == 'drone')) && (ENV['DRONE'] == 'true')
            DRONEIO
+         elsif (ENV['CI'] == 'true') && (ENV['GITHUB_ACTIONS'] == 'true')
+           GITHUB
          elsif !ENV['GITLAB_CI'].nil?
            GITLAB
          elsif ENV['HEROKU_TEST_RUN_ID']
@@ -172,6 +175,15 @@ class SimpleCov::Formatter::Codecov
       params[:build_url] = ENV['DRONE_BUILD_LINK'] || ENV['DRONE_BUILD_URL'] || ENV['CI_BUILD_URL']
       params[:pr] = ENV['DRONE_PULL_REQUEST']
       params[:tag] = ENV['DRONE_TAG']
+    when GITHUB
+      # https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
+      params[:service] = 'github-actions'
+      params[:branch] = ENV['GITHUB_HEAD_REF'] || ENV['GITHUB_REF'].sub('refs/heads/', '')
+      # PR refs are in the format: refs/pull/7/merge
+      params[:pr] = ENV['GITHUB_REF'].split('/')[2] if ENV['GITHUB_HEAD_REF']
+      params[:slug] = ENV['GITHUB_REPOSITORY']
+      params[:build] = ENV['GITHUB_RUN_ID']
+      params[:commit] = ENV['GITHUB_SHA']
     when GITLAB
       # http://doc.gitlab.com/ci/examples/README.html#environmental-variables
       # https://gitlab.com/gitlab-org/gitlab-ci-runner/blob/master/lib/build.rb#L96

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -6,7 +6,16 @@ class TestCodecov < Minitest::Test
   CI = SimpleCov::Formatter::Codecov.new.detect_ci
 
   REALENV =
-    if CI == SimpleCov::Formatter::Codecov::TRAVIS
+    if CI == SimpleCov::Formatter::Codecov::GITHUB
+      {
+        'GITHUB_ACTIONS' => ENV['GITHUB_ACTIONS'],
+        'GITHUB_HEAD_REF' => ENV['GITHUB_HEAD_REF'],
+        'GITHUB_REF' => ENV['GITHUB_REF'],
+        'GITHUB_REPOSITORY' => ENV['GITHUB_REPOSITORY'],
+        'GITHUB_RUN_ID' => ENV['GITHUB_RUN_ID'],
+        'GITHUB_SHA' => ENV['GITHUB_SHA']
+      }
+    elsif CI == SimpleCov::Formatter::Codecov::TRAVIS
       {
         'TRAVIS' => ENV['TRAVIS'],
         'TRAVIS_BRANCH' => ENV['TRAVIS_BRANCH'],
@@ -15,10 +24,10 @@ class TestCodecov < Minitest::Test
         'TRAVIS_JOB_NUMBER' => ENV['TRAVIS_JOB_NUMBER'],
         'TRAVIS_PULL_REQUEST' => ENV['TRAVIS_PULL_REQUEST'],
         'TRAVIS_JOB_ID' => ENV['TRAVIS_JOB_ID']
-      }.freeze
+      }
     else
       {}
-    end
+    end.freeze
 
   def url
     ENV['CODECOV_URL'] || 'https://codecov.io'

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -94,6 +94,7 @@ class TestCodecov < Minitest::Test
 
   def setup
     ENV['CI'] = nil
+    ENV['GITHUB_ACTIONS'] = nil
     ENV['TRAVIS'] = nil
   end
 

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -150,6 +150,12 @@ class TestCodecov < Minitest::Test
     ENV['ghprbSourceBranch'] = nil
     ENV['GIT_BRANCH'] = nil
     ENV['GIT_COMMIT'] = nil
+    ENV['GITHUB_ACTIONS'] = nil
+    ENV['GITHUB_REF'] = nil
+    ENV['GITHUB_HEAD_REF'] = nil
+    ENV['GITHUB_REPOSITORY'] = nil
+    ENV['GITHUB_RUN_ID'] = nil
+    ENV['GITHUB_SHA'] = nil
     ENV['GITLAB_CI'] = nil
     ENV['HEROKU_TEST_RUN_ID'] = nil
     ENV['HEROKU_TEST_RUN_BRANCH'] = nil
@@ -397,6 +403,22 @@ class TestCodecov < Minitest::Test
     assert_equal('1', result['params'][:build])
     assert_equal('master', result['params'][:branch])
     assert_equal('owner/repo', result['params'][:slug])
+    assert_equal('f881216b-b5c0-4eb1-8f21-b51887d1d506', result['params']['token'])
+  end
+
+  def test_github
+    ENV['CI'] = 'true'
+    ENV['GITHUB_ACTIONS'] = 'true'
+    ENV['GITHUB_REF'] = 'refs/head/master'
+    ENV['GITHUB_REPOSITORY'] = 'codecov/ci-repo'
+    ENV['GITHUB_RUN_ID'] = '1'
+    ENV['GITHUB_SHA'] = 'c739768fcac68144a3a6d82305b9c4106934d31a'
+    ENV['CODECOV_TOKEN'] = 'f881216b-b5c0-4eb1-8f21-b51887d1d506'
+    result = upload
+    assert_equal('github-actions', result['params'][:service])
+    assert_equal('c739768fcac68144a3a6d82305b9c4106934d31a', result['params'][:commit])
+    assert_equal('codecov/ci-repo', result['params'][:slug])
+    assert_equal('1', result['params'][:build])
     assert_equal('f881216b-b5c0-4eb1-8f21-b51887d1d506', result['params']['token'])
   end
 


### PR DESCRIPTION
This PR is based on https://github.com/codecov/codecov-ruby/pull/52 and [codecov-bash](https://github.com/codecov/codecov-bash/blob/9780730db999db8f4342a3a1c376d3027178f04a/codecov#L790-L810).

Supporting GitHub Actions by codecov-ruby is necessary because codecov-action is not working with SimpleCov.