### PR TITLE
Pin Ruby version to 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,4 @@ rvm:
   - 2.6
   - 2.7
   - jruby
-  - jruby-9.1
   - jruby-9.2

--- a/codecov.gemspec
+++ b/codecov.gemspec
@@ -1,18 +1,19 @@
 # frozen_string_literal: true
 
 Gem::Specification.new do |s|
-  s.name               = 'codecov'
-  s.version            = '0.2.5'
-  s.platform           = Gem::Platform::RUBY
-  s.authors            = ['codecov']
-  s.email              = ['hello@codecov.io']
-  s.description        = 'hosted code coverage'
-  s.homepage           = 'https://github.com/codecov/codecov-ruby'
-  s.summary            = 'hosted code coverage ruby/rails reporter'
-  s.license            = 'MIT'
-  s.files              = ['lib/codecov.rb']
-  s.test_files         = ['test/test_codecov.rb']
-  s.require_paths      = ['lib']
+  s.name                  = 'codecov'
+  s.authors               = ['codecov']
+  s.description           = 'hosted code coverage'
+  s.email                 = ['hello@codecov.io']
+  s.files                 = ['lib/codecov.rb']
+  s.homepage              = 'https://github.com/codecov/codecov-ruby'
+  s.license               = 'MIT'
+  s.platform              = Gem::Platform::RUBY
+  s.require_paths         = ['lib']
+  s.required_ruby_version = '>=2.4'
+  s.summary               = 'hosted code coverage ruby/rails reporter'
+  s.test_files            = ['test/test_codecov.rb']
+  s.version               = '0.2.5'
 
   s.add_dependency 'colorize'
   s.add_dependency 'json'


### PR DESCRIPTION
Rubocop and `&.` notation require at least `2.4` (technically `&.` is 2.3)