### PR TITLE
Add better handling of errors on request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### `0.2.10`
 - Adds better logging on error cases
+- Add more invalid directories in the network
 
 ### `0.2.9`
 - Remove `String` specific colors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### `0.2.10`
+- Adds better logging on error cases
+
 ### `0.2.9`
 - Remove `String` specific colors
 - Add support for Codebuild CI

--- a/codecov.gemspec
+++ b/codecov.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>=2.4'
   s.summary               = 'hosted code coverage ruby/rails reporter'
   s.test_files            = ['test/test_codecov.rb']
-  s.version               = '0.2.9'
+  s.version               = '0.2.10'
 
   s.add_dependency 'json'
   s.add_dependency 'simplecov'

--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -509,16 +509,20 @@ class SimpleCov::Formatter::Codecov
     ].freeze
 
     invalid_directories = [
-      'node_modules/'
+      'node_modules/',
+      'public/',
+      'storage/',
+      'tmp/'
     ]
 
     puts [green('==>'), 'Appending file network'].join(' ')
     network = []
     Dir['**/*'].keep_if do |file|
-      if File.file?(file) && !file.end_with?(*invalid_file_types) && !file.include?(*invalid_directories)
+      if File.file?(file) && !file.end_with?(*invalid_file_types) && invalid_directories.none? { |dir| file.include?(dir) }
         network.push(file)
       end
     end
+
     network.push('<<<<<< network')
     network
   end

--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -7,7 +7,7 @@ require 'simplecov'
 require 'zlib'
 
 class SimpleCov::Formatter::Codecov
-  VERSION = '0.2.9'
+  VERSION = '0.2.10'
 
   ### CIs
   RECOGNIZED_CIS = [
@@ -319,6 +319,7 @@ class SimpleCov::Formatter::Codecov
       puts 'Error uploading coverage reports to Codecov. Sorry'
       puts e.class.name
       puts e
+      puts "Backtrace:\n\t#{e.backtrace}"
       return response
     end
 
@@ -414,7 +415,7 @@ class SimpleCov::Formatter::Codecov
     )
     req.body = report
     res = retry_request(req, https)
-    if res.body == ''
+    if res&.body == ''
       {
         'uploaded' => true,
         'url' => reports_url,
@@ -425,7 +426,7 @@ class SimpleCov::Formatter::Codecov
       }.to_json
     else
       puts [black('-> '), 'Could not upload reports via v4 API, defaulting to v2'].join(' ')
-      puts red(res.body)
+      puts red(res&.body || 'nil')
       nil
     end
   end


### PR DESCRIPTION
Fix for https://community.codecov.io/t/cannot-upload-to-codecov-after-upgrade-to-0-2-8-codecov-ruby-gem/1912/6