### PR TITLE
Fix value of params[:pr] when useing CodeBuild 

### DIFF
--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -168,7 +168,10 @@ class SimpleCov::Formatter::Codecov
       params[:commit] = ENV['CODEBUILD_RESOLVED_SOURCE_VERSION']
       params[:job] = ENV['CODEBUILD_BUILD_ID']
       params[:slug] = ENV['CODEBUILD_SOURCE_REPO_URL'].match(/.*github.com\/(?<slug>.*).git/)['slug']
-      params[:pr] = ENV['CODEBUILD_SOURCE_VERSION'].match(/pr\/(?<pr>.*)/)['pr'] if ENV['CODEBUILD_SOURCE_VERSION']
+      params[:pr] = if ENV['CODEBUILD_SOURCE_VERSION']
+                      matched = ENV['CODEBUILD_SOURCE_VERSION'].match(%r{pr/(?<pr>.*)})
+                      matched.nil? ? ENV['CODEBUILD_SOURCE_VERSION'] : matched['pr']
+                    end
     when CODESHIP
       # https://www.codeship.io/documentation/continuous-integration/set-environment-variables/
       params[:service] = 'codeship'

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -639,6 +639,27 @@ class TestCodecov < Minitest::Test
     assert_equal('f881216b-b5c0-4eb1-8f21-b51887d1d506', result['params']['token'])
   end
 
+  def test_codebuild_source_version_is_other_than_pr_number
+    ENV['CODEBUILD_CI'] = 'true'
+    ENV['CODEBUILD_BUILD_ID'] = 'codebuild-project:458dq3q8-7354-4513-8702-ea7b9c81efb3'
+    ENV['CODEBUILD_RESOLVED_SOURCE_VERSION'] = 'd653b934ed59c1a785cc1cc79d08c9aaa4eba73b'
+    ENV['CODEBUILD_WEBHOOK_HEAD_REF'] = 'refs/heads/master'
+    ENV['CODEBUILD_SOURCE_VERSION'] = 'git-commit-hash-12345'
+    ENV['CODEBUILD_SOURCE_REPO_URL'] = 'https://github.com/owner/repo.git'
+    ENV['CODECOV_TOKEN'] = 'f881216b-b5c0-4eb1-8f21-b51887d1d506'
+
+    result = upload
+
+    assert_equal('codebuild', result['params'][:service])
+    assert_equal('d653b934ed59c1a785cc1cc79d08c9aaa4eba73b', result['params'][:commit])
+    assert_equal('codebuild-project:458dq3q8-7354-4513-8702-ea7b9c81efb3', result['params'][:build])
+    assert_equal('git-commit-hash-12345', result['params'][:pr])
+    assert_equal('owner/repo', result['params'][:slug])
+    assert_equal('master', result['params'][:branch])
+    assert_equal('git-commit-hash-12345', result['params'][:pr])
+    assert_equal('f881216b-b5c0-4eb1-8f21-b51887d1d506', result['params']['token'])
+  end
+
   def test_filenames_are_shortened_correctly
     ENV['CODECOV_TOKEN'] = 'f881216b-b5c0-4eb1-8f21-b51887d1d506'
 


### PR DESCRIPTION
The value of `CODE_BUILD_SOURCE_VERSION` is not only pull request number but also commit id, branch name and tag name.

AWS says like this in [the documentation](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html). 
>CODEBUILD_SOURCE_VERSION
The value's format depends on the source repository.
For Amazon S3, it is the version ID associated with the input artifact.
For CodeCommit, it is the commit ID or branch name associated with the version of the source code to be built.
For GitHub, GitHub Enterprise Server, and Bitbucket it is the commit ID, branch name, or tag name associated with the version of the source code to be built.
Note
For a GitHub or GitHub Enterprise Server build that is triggered by a webhook pull request event, it is pr/pull-request-number.


When the value is not pull request number, an error raises so I fix the code.

Here's error messages.

```
==> Codebuild CI detected
--
850 | ==> Appending file network
851 | /root/caches/vendor/bundle/ruby/2.5.0/gems/codecov-0.2.11/lib/codecov.rb:171:in `build_params': undefined method `[]' for nil:NilClass (NoMethodError)
852 | from /root/caches/vendor/bundle/ruby/2.5.0/gems/codecov-0.2.11/lib/codecov.rb:354:in `upload_to_codecov'
853 | from /root/caches/vendor/bundle/ruby/2.5.0/gems/codecov-0.2.11/lib/codecov.rb:470:in `format'
854 | from /root/caches/vendor/bundle/ruby/2.5.0/gems/simplecov-0.19.0/lib/simplecov/result.rb:51:in `format!'
855 | from /root/caches/vendor/bundle/ruby/2.5.0/gems/simplecov-0.19.0/lib/simplecov/configuration.rb:196:in `block in at_exit'
856 | from /root/caches/vendor/bundle/ruby/2.5.0/gems/simplecov-0.19.0/lib/simplecov.rb:189:in `run_exit_tasks!'
857 | from /root/caches/vendor/bundle/ruby/2.5.0/gems/simplecov-0.19.0/lib/simplecov.rb:179:in `at_exit_behavior'
858 | from /root/caches/vendor/bundle/ruby/2.5.0/gems/simplecov-0.19.0/lib/simplecov/defaults.rb:27:in `block in <top (required)>'
```