### PR TITLE
Remove unnecessary dependency for ruby standard gem

### DIFF
--- a/codecov.gemspec
+++ b/codecov.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.test_files            = ['test/test_codecov.rb']
   s.version               = '0.2.12'
 
-  s.add_dependency 'json'
   s.add_dependency 'simplecov'
 
   s.add_development_dependency 'minitest'


### PR DESCRIPTION
I want to reduce unnecessary dependency from my product's `Gemfile.lock`.
The `json` gem is contained in the ruby standard gems.
They get automatically installed when you install Ruby.

The following `Gemfile.lock` is minimum project example that using codecov.


#### Gemfile.lock (before this PR)

```
GEM
  remote: https://rubygems.org/
  specs:
    codecov (0.2.12)
      json
      simplecov
    docile (1.3.2)
    json (2.3.1)
    simplecov (0.19.0)
      docile (~> 1.1)
      simplecov-html (~> 0.11)
    simplecov-html (0.12.3)

PLATFORMS
  ruby

DEPENDENCIES
  codecov

BUNDLED WITH
   2.1.4
```

#### Gemfile.lock (after this PR)

```
GEM
  remote: https://rubygems.org/
  specs:
    docile (1.3.2)
    simplecov (0.19.0)
      docile (~> 1.1)
      simplecov-html (~> 0.11)
    simplecov-html (0.12.3)

PLATFORMS
  ruby

DEPENDENCIES
  codecov

BUNDLED WITH
   2.1.4
```
