### PR TITLE
Gemspec improvements

### DIFF
--- a/codecov.gemspec
+++ b/codecov.gemspec
@@ -13,12 +13,12 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '~> 2.4'
   s.version               = '0.2.12'
 
-  s.add_dependency 'simplecov'
+  s.add_dependency 'simplecov', '~> 0.18.0'
 
-  s.add_development_dependency 'minitest'
-  s.add_development_dependency 'minitest-ci'
-  s.add_development_dependency 'mocha'
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'rubocop'
-  s.add_development_dependency 'webmock'
+  s.add_development_dependency 'minitest', '~> 5.0'
+  s.add_development_dependency 'minitest-ci', '~> 3.0'
+  s.add_development_dependency 'mocha', '~> 1.0'
+  s.add_development_dependency 'rake', '~> 13.0'
+  s.add_development_dependency 'rubocop', '~> 1.0'
+  s.add_development_dependency 'webmock', '~> 3.0'
 end

--- a/codecov.gemspec
+++ b/codecov.gemspec
@@ -3,7 +3,8 @@
 Gem::Specification.new do |s|
   s.name                  = 'codecov'
   s.authors               = ['Steve Peak', 'Tom Hu']
-  s.description           = 'hosted code coverage'
+  s.summary               = 'Hosted code coverage'
+  s.description           = 'Hosted code coverage Ruby reporter.'
   s.email                 = ['hello@codecov.io']
   s.files                 = ['lib/codecov.rb']
   s.homepage              = 'https://github.com/codecov/codecov-ruby'
@@ -11,7 +12,6 @@ Gem::Specification.new do |s|
   s.platform              = Gem::Platform::RUBY
   s.require_paths         = ['lib']
   s.required_ruby_version = '>=2.4'
-  s.summary               = 'hosted code coverage ruby/rails reporter'
   s.test_files            = ['test/test_codecov.rb']
   s.version               = '0.2.12'
 

--- a/codecov.gemspec
+++ b/codecov.gemspec
@@ -10,9 +10,7 @@ Gem::Specification.new do |s|
   s.homepage              = 'https://github.com/codecov/codecov-ruby'
   s.license               = 'MIT'
   s.platform              = Gem::Platform::RUBY
-  s.require_paths         = ['lib']
   s.required_ruby_version = '>=2.4'
-  s.test_files            = ['test/test_codecov.rb']
   s.version               = '0.2.12'
 
   s.add_dependency 'simplecov'

--- a/codecov.gemspec
+++ b/codecov.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name                  = 'codecov'
-  s.authors               = ['codecov']
+  s.authors               = ['Steve Peak', 'Tom Hu']
   s.description           = 'hosted code coverage'
   s.email                 = ['hello@codecov.io']
   s.files                 = ['lib/codecov.rb']

--- a/codecov.gemspec
+++ b/codecov.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.homepage              = 'https://github.com/codecov/codecov-ruby'
   s.license               = 'MIT'
   s.platform              = Gem::Platform::RUBY
-  s.required_ruby_version = '>=2.4'
+  s.required_ruby_version = '~> 2.4'
   s.version               = '0.2.12'
 
   s.add_dependency 'simplecov'


### PR DESCRIPTION
*   Specify actual authors of the gem
*   Fix and improve gem's `summary` and `description`
*   Remove useless `require_paths` and `test_files`
*   Improve required Ruby version lock, avoid 3.0
*   Add versions locks for dependencies
    It's very dangerous and unstable to have dependencies without any version lock,
    they may update at any time and without backward compatibility.