### PR TITLE
Fix branch name detection for GitHub Actions CI

### DIFF
--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -192,9 +192,13 @@ class SimpleCov::Formatter::Codecov
     when GITHUB
       # https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
       params[:service] = 'github-actions'
-      params[:branch] = ENV['GITHUB_HEAD_REF'] || ENV['GITHUB_REF'].sub('refs/heads/', '')
-      # PR refs are in the format: refs/pull/7/merge for pull_request events
-      params[:pr] = ENV['GITHUB_REF'].split('/')[2] unless ENV['GITHUB_HEAD_REF'].nil? || ENV['GITHUB_HEAD_REF'].empty?
+      if (ENV['GITHUB_HEAD_REF'] || '').empty?
+        params[:branch] = ENV['GITHUB_REF'].sub('refs/heads/', '')
+      else
+        params[:branch] = ENV['GITHUB_HEAD_REF']
+        # PR refs are in the format: refs/pull/7/merge for pull_request events
+        params[:pr] = ENV['GITHUB_REF'].split('/')[2]
+      end
       params[:slug] = ENV['GITHUB_REPOSITORY']
       params[:build] = ENV['GITHUB_RUN_ID']
       params[:commit] = ENV['GITHUB_SHA']

--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -192,7 +192,7 @@ class SimpleCov::Formatter::Codecov
     when GITHUB
       # https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
       params[:service] = 'github-actions'
-      params[:branch] = ENV['GITHUB_HEAD_REF'] || ENV['GITHUB_REF'].sub('refs/head/', '')
+      params[:branch] = ENV['GITHUB_HEAD_REF'] || ENV['GITHUB_REF'].sub('refs/heads/', '')
       # PR refs are in the format: refs/pull/7/merge for pull_request events
       params[:pr] = ENV['GITHUB_REF'].split('/')[2] unless ENV['GITHUB_HEAD_REF'].nil? || ENV['GITHUB_HEAD_REF'].empty?
       params[:slug] = ENV['GITHUB_REPOSITORY']

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -485,7 +485,7 @@ class TestCodecov < Minitest::Test
     ENV['CI'] = 'true'
     ENV['GITHUB_ACTIONS'] = 'true'
     ENV['GITHUB_HEAD_REF'] = nil
-    ENV['GITHUB_REF'] = 'refs/head/master'
+    ENV['GITHUB_REF'] = 'refs/heads/master'
     ENV['GITHUB_REPOSITORY'] = 'codecov/ci-repo'
     ENV['GITHUB_RUN_ID'] = '1'
     ENV['GITHUB_SHA'] = 'c739768fcac68144a3a6d82305b9c4106934d31a'

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -484,7 +484,7 @@ class TestCodecov < Minitest::Test
   def test_github_push
     ENV['CI'] = 'true'
     ENV['GITHUB_ACTIONS'] = 'true'
-    ENV['GITHUB_HEAD_REF'] = nil
+    ENV['GITHUB_HEAD_REF'] = ''
     ENV['GITHUB_REF'] = 'refs/heads/master'
     ENV['GITHUB_REPOSITORY'] = 'codecov/ci-repo'
     ENV['GITHUB_RUN_ID'] = '1'


### PR DESCRIPTION
This pull request fixes two problems, expecting `GITHUB_REF` to contain 'head' instead of 'head**s**' and also not detecting empty string in `GITHUB_HEAD_REF` as falsey.

Without this patch all my commits were considered as being coming from the default branch. I required all fixes to make it work, including GITHUB_HEAD_REF issue as GitHub was providing me an empty string instead of leaving the variable undefined (verified with code below):
```yml
    steps:
    - name: Debug codecov
      run: |
        ruby -e '["GITHUB_REF", "GITHUB_HEAD_REF", "GITHUB_SHA", "GITHUB_REPOSITORY", "GITHUB_RUN_ID"].each { |v| puts "#{v}: #{ENV[v].inspect}" }'
```