### PR TITLE
Return version constant, don't duplicate version value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test install build deploy
 
 deploy:
-	$(eval VERSION := $(shell cat lib/codecov.rb | grep 'VERSION = ' | cut -d\' -f2))
+	$(eval VERSION := $(shell cat lib/codecov/version.rb | grep 'VERSION = ' | cut -d\' -f2))
 	git tag v$(VERSION) -m ""
 	git push origin v$(VERSION)
 	gem build codecov.gemspec

--- a/codecov.gemspec
+++ b/codecov.gemspec
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'lib/codecov/version'
+
 Gem::Specification.new do |s|
   s.name                  = 'codecov'
   s.authors               = ['codecov']
@@ -13,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>=2.4'
   s.summary               = 'hosted code coverage ruby/rails reporter'
   s.test_files            = ['test/test_codecov.rb']
-  s.version               = '0.2.12'
+  s.version               = ::Codecov::VERSION
 
   s.add_dependency 'simplecov'
 

--- a/lib/codecov.rb
+++ b/lib/codecov.rb
@@ -6,9 +6,9 @@ require 'net/http'
 require 'simplecov'
 require 'zlib'
 
-class SimpleCov::Formatter::Codecov
-  VERSION = '0.2.12'
+require_relative 'codecov/version'
 
+class SimpleCov::Formatter::Codecov
   ### CIs
   RECOGNIZED_CIS = [
     APPVEYOR = 'Appveyor CI',
@@ -41,7 +41,7 @@ class SimpleCov::Formatter::Codecov
       '| |    / _ \ / _\`|/ _ \/ __/ _ \ \ / /',
       '| |___| (_) | (_| |  __/ (_| (_) \ V /',
       ' \_____\___/ \__,_|\___|\___\___/ \_/',
-      "                               Ruby-#{VERSION}",
+      "                               Ruby-#{::Codecov::VERSION}",
       ''
     ].join("\n")
   end
@@ -100,7 +100,7 @@ class SimpleCov::Formatter::Codecov
     params = {
       'token' => ENV['CODECOV_TOKEN'],
       'flags' => ENV['CODECOV_FLAG'] || ENV['CODECOV_FLAGS'],
-      'package' => "ruby-#{VERSION}"
+      'package' => "ruby-#{::Codecov::VERSION}"
     }
 
     case ci
@@ -336,7 +336,7 @@ class SimpleCov::Formatter::Codecov
   def create_report(report)
     result = {
       'meta' => {
-        'version' => 'codecov-ruby/v' + VERSION
+        'version' => 'codecov-ruby/v' + ::Codecov::VERSION
       }
     }
     result.update(result_to_codecov(report))

--- a/lib/codecov/version.rb
+++ b/lib/codecov/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Codecov
-	VERSION = '0.2.12'
+	VERSION = '0.2.13'
 end

--- a/lib/codecov/version.rb
+++ b/lib/codecov/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Codecov
+	VERSION = '0.2.12'
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,7 +7,7 @@ require 'simplecov'
 SimpleCov.start do
   add_filter '/test/'
 end
-require 'codecov'
+require_relative '../lib/codecov'
 SimpleCov.formatter = SimpleCov::Formatter::Codecov if ENV['CI'] == 'true'
 
 require 'minitest/autorun'

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'helper'
+require_relative 'helper'
 
 class TestCodecov < Minitest::Test
   CI = SimpleCov::Formatter::Codecov.new.detect_ci
@@ -47,7 +47,7 @@ class TestCodecov < Minitest::Test
 
   def test_defined
     assert defined?(SimpleCov::Formatter::Codecov)
-    assert defined?(SimpleCov::Formatter::Codecov::VERSION)
+    assert defined?(::Codecov::VERSION)
   end
 
   def stub_file(filename, coverage)
@@ -96,7 +96,7 @@ class TestCodecov < Minitest::Test
   def assert_successful_upload(data)
     assert_equal(data['result']['uploaded'], true)
     assert_equal(data['result']['message'], 'Coverage reports upload successfully')
-    assert_equal(data['meta']['version'], 'codecov-ruby/v' + SimpleCov::Formatter::Codecov::VERSION)
+    assert_equal(data['meta']['version'], 'codecov-ruby/v' + ::Codecov::VERSION)
     assert_equal(data['coverage'].to_json, {
       'lib/something.rb' => [nil, 1, 0, 0, nil, 1, nil],
       'lib/somefile.rb' => [nil, 1, nil, 1, 1, 1, 0, 0, nil, 1, nil]


### PR DESCRIPTION
Kind of revert 6c2856ec4dda8a61b637b8dc1e6ca341c06d95d3
without regression of #84
because of `require_relative` instead of `$LOAD_PATH.unshift`.

/cc @thomasrockhu @hootener @colindean as members of related issues.