### PR TITLE
Include codecov/version in the gem

### DIFF
--- a/codecov.gemspec
+++ b/codecov.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.summary               = 'Hosted code coverage'
   s.description           = 'Hosted code coverage Ruby reporter.'
   s.email                 = ['hello@codecov.io']
-  s.files                 = ['lib/codecov.rb']
+  s.files                 = ['lib/codecov.rb', 'lib/codecov/version.rb']
   s.homepage              = 'https://github.com/codecov/codecov-ruby'
   s.license               = 'MIT'
   s.platform              = Gem::Platform::RUBY


### PR DESCRIPTION
This prevents LoadError in here.
https://github.com/codecov/codecov-ruby/blob/343dbbbc11938c8c9935ccd9df5a9c2c4bdea95a/lib/codecov.rb#L9