### PR TITLE
open simplecov requirement to 0.21.x

### DIFF
--- a/codecov.gemspec
+++ b/codecov.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '~> 2.4'
   s.version               = ::Codecov::VERSION
 
-  s.add_dependency 'simplecov', '>= 0.15', '< 0.21'
+  s.add_dependency 'simplecov', '>= 0.15', '< 0.22'
 
   s.add_development_dependency 'minitest', '~> 5.0'
   s.add_development_dependency 'minitest-ci', '~> 3.0'


### PR DESCRIPTION
This PR allows the [latest version](https://github.com/simplecov-ruby/simplecov/releases/tag/v0.21.2) of simplecov. 0.21.x was explicitly excluded, but I see no issues and tests pass. Please let me know if I'm missing anything.