### PR TITLE
fix crash and support CodeBuild under CodePipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Repo tokens are **not** required for public repos on Travis-Ci, CircleCI, or App
 | [Bitrise CI](https://www.bitrise.io/) |
 | [Buildkite CI](https://buildkite.com/) |
 | [CodeBuild CI](https://aws.amazon.com/codebuild/) |
+| [CodePipeline](https://aws.amazon.com/codepipeline/) |
 | [Circle CI](https://circleci.com/) |
 | [Codeship CI](https://codeship.com/) |
 | [Drone CI](https://drone.io/) |

--- a/lib/codecov/uploader.rb
+++ b/lib/codecov/uploader.rb
@@ -187,16 +187,18 @@ class Codecov::Uploader
       # 2. Add a Namespace to your source action. Example: "CodeStar".
       #    https://docs.aws.amazon.com/codepipeline/latest/userguide/reference-variables.html#reference-variables-concepts-namespaces
       # 3. Add these environment variables to your CodeBuild action:
-      #   - CODESTAR_BRANCH_NAME: #{GitHub.BranchName}
-      #   - CODESTAR_FULL_REPOSITORY_NAME: #{GitHub.FullRepositoryName} (optional)
+      #   - CODESTAR_BRANCH_NAME: #{CodeStar.BranchName}
+      #   - CODESTAR_FULL_REPOSITORY_NAME: #{CodeStar.FullRepositoryName} (optional)
       #     https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-CodeBuild.html#action-reference-CodeBuild-config
+      #
+      # PRs are not supported with CodePipeline.
       params[:service] = 'codebuild'
       params[:branch] = ENV['CODEBUILD_WEBHOOK_HEAD_REF']&.split('/')&.[](2) || ENV['CODESTAR_BRANCH_NAME']
       params[:build] = ENV['CODEBUILD_BUILD_ID']
       params[:commit] = ENV['CODEBUILD_RESOLVED_SOURCE_VERSION']
       params[:job] = ENV['CODEBUILD_BUILD_ID']
       params[:slug] = ENV['CODEBUILD_SOURCE_REPO_URL']&.match(/.*github.com\/(?<slug>.*).git/)&.[]('slug') || ENV['CODESTAR_FULL_REPOSITORY_NAME']
-      params[:pr] = if ENV['CODEBUILD_SOURCE_VERSION']
+      params[:pr] = if ENV['CODEBUILD_SOURCE_VERSION'] && !(ENV['CODEBUILD_INITIATOR'] =~ /codepipeline/)
                       matched = ENV['CODEBUILD_SOURCE_VERSION'].match(%r{pr/(?<pr>.*)})
                       matched.nil? ? ENV['CODEBUILD_SOURCE_VERSION'] : matched['pr']
                     end

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -169,10 +169,14 @@ class TestCodecov < Minitest::Test
     ENV['CIRCLECI'] = nil
     ENV['CODEBUILD_CI'] = nil
     ENV['CODEBUILD_BUILD_ID'] = nil
+    ENV['CODEBUILD_BUILD_URL'] = nil
+    ENV['CODEBUILD_INITIATOR'] = nil
     ENV['CODEBUILD_RESOLVED_SOURCE_VERSION'] = nil
     ENV['CODEBUILD_WEBHOOK_HEAD_REF'] = nil
     ENV['CODEBUILD_SOURCE_VERSION'] = nil
     ENV['CODEBUILD_SOURCE_REPO_URL'] = nil
+    ENV['CODESTAR_BRANCH_NAME'] = nil
+    ENV['CODESTAR_FULL_REPOSITORY_NAME'] = nil
     ENV['CODECOV_ENV'] = nil
     ENV['CODECOV_SLUG'] = nil
     ENV['CODECOV_TOKEN'] = nil
@@ -636,6 +640,32 @@ class TestCodecov < Minitest::Test
     assert_equal("owner/repo", result['params'][:slug])
     assert_equal("master", result['params'][:branch])
     assert_equal("123", result['params'][:pr])
+    assert_equal('f881216b-b5c0-4eb1-8f21-b51887d1d506', result['params']['token'])
+  end
+
+  def test_codebuild_codepipeline
+    ENV['CODEBUILD_CI'] = "true"
+    ENV['CODEBUILD_INITIATOR'] = "codepipeline/codepipeline-name"
+    ENV['CODEBUILD_BUILD_ID'] = "codebuild-project:458dq3q8-7354-4513-8702-ea7b9c81efb3"
+    ENV['CODEBUILD_BUILD_URL'] = "https://us-east-1.console.aws.amazon.com/codebuild/home?region=us-east-1#/builds/codebuild-project:458dq3q8-7354-4513-8702-ea7b9c81efb3/view/new"
+    ENV['CODEBUILD_RESOLVED_SOURCE_VERSION'] = 'd653b934ed59c1a785cc1cc79d08c9aaa4eba73b'
+    ENV['CODEBUILD_WEBHOOK_HEAD_REF'] = nil
+    ENV['CODEBUILD_SOURCE_VERSION'] = 'arn:aws:s3:::bucket/codepipeline-name/SourceActionName/cf4IT8b'
+    ENV['CODEBUILD_SOURCE_REPO_URL'] = nil
+    # set CodeStarSourceConnection namespace and CodeBuild variables manually in CodePipeline, see source code comments
+    ENV['CODESTAR_BRANCH_NAME'] = 'branch-name'
+    ENV['CODESTAR_FULL_REPOSITORY_NAME'] = 'owner/repo'
+    ENV['CODECOV_TOKEN'] = 'f881216b-b5c0-4eb1-8f21-b51887d1d506'
+
+    result = upload
+
+    assert_equal("codebuild", result['params'][:service])
+    assert_equal("d653b934ed59c1a785cc1cc79d08c9aaa4eba73b", result['params'][:commit])
+    assert_equal("codebuild-project:458dq3q8-7354-4513-8702-ea7b9c81efb3", result['params'][:build])
+    assert_equal("codebuild-project:458dq3q8-7354-4513-8702-ea7b9c81efb3", result['params'][:job])
+    assert_equal("owner/repo", result['params'][:slug])
+    assert_equal("branch-name", result['params'][:branch])
+    assert_equal("arn:aws:s3:::bucket/codepipeline-name/SourceActionName/cf4IT8b", result['params'][:pr])
     assert_equal('f881216b-b5c0-4eb1-8f21-b51887d1d506', result['params']['token'])
   end
 

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -647,7 +647,7 @@ class TestCodecov < Minitest::Test
     ENV['CODEBUILD_CI'] = "true"
     ENV['CODEBUILD_INITIATOR'] = "codepipeline/codepipeline-name"
     ENV['CODEBUILD_BUILD_ID'] = "codebuild-project:458dq3q8-7354-4513-8702-ea7b9c81efb3"
-    ENV['CODEBUILD_BUILD_URL'] = "https://us-east-1.console.aws.amazon.com/codebuild/home?region=us-east-1#/builds/codebuild-project:458dq3q8-7354-4513-8702-ea7b9c81efb3/view/new"
+    ENV['CODEBUILD_BUILD_URL'] = "http://codebuild"
     ENV['CODEBUILD_RESOLVED_SOURCE_VERSION'] = 'd653b934ed59c1a785cc1cc79d08c9aaa4eba73b'
     ENV['CODEBUILD_WEBHOOK_HEAD_REF'] = nil
     ENV['CODEBUILD_SOURCE_VERSION'] = 'arn:aws:s3:::bucket/codepipeline-name/SourceActionName/cf4IT8b'
@@ -662,6 +662,7 @@ class TestCodecov < Minitest::Test
     assert_equal("codebuild", result['params'][:service])
     assert_equal("d653b934ed59c1a785cc1cc79d08c9aaa4eba73b", result['params'][:commit])
     assert_equal("codebuild-project:458dq3q8-7354-4513-8702-ea7b9c81efb3", result['params'][:build])
+    assert_equal("http://codebuild", result['params'][:build_url])
     assert_equal("codebuild-project:458dq3q8-7354-4513-8702-ea7b9c81efb3", result['params'][:job])
     assert_equal("owner/repo", result['params'][:slug])
     assert_equal("branch-name", result['params'][:branch])

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -666,7 +666,7 @@ class TestCodecov < Minitest::Test
     assert_equal("codebuild-project:458dq3q8-7354-4513-8702-ea7b9c81efb3", result['params'][:job])
     assert_equal("owner/repo", result['params'][:slug])
     assert_equal("branch-name", result['params'][:branch])
-    assert_equal("arn:aws:s3:::bucket/codepipeline-name/SourceActionName/cf4IT8b", result['params'][:pr])
+    assert_nil(result['params'][:pr])
     assert_equal('f881216b-b5c0-4eb1-8f21-b51887d1d506', result['params']['token'])
   end
 


### PR DESCRIPTION
CodeBuild under CodePipeline sets environment variables differently, causing `Formatter SimpleCov::Formatter::Codecov failed with NoMethodError: undefined method `split' for nil:NilClass`. This PR fixes that. 

Branch name and slug are supported too, but need some setup. These instructions are included in the source. (I couldn't a home for these elsewhere):

### CodePipeline with CodeBuild

To setup branch and slug with CodePipeline as CodeBuild source:

1. Set up CodeStarSourceConnection as source action provider
   See [AWS CodePipeline CodeStarConnection Reference](https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-CodestarConnectionSource.html).
1. Add a Namespace to your source action. Example: "CodeStar"
    See [AWS CodePipeline Namespaces Reference](https://docs.aws.amazon.com/codepipeline/latest/userguide/reference-variables.html#reference-variables-concepts-namespaces).
1. Add these environment variables to your CodeBuild action:
   - `CODESTAR_BRANCH_NAME`: set to `#{GitHub.BranchName}`
   - `CODESTAR_FULL_REPOSITORY_NAME`: set to `#{GitHub.FullRepositoryName} (optional)`
    See [AWS CodePipeline Action Reference](https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-CodeBuild.html#action-reference-CodeBuild-config).


(Uploading PR number support is unfortunately not included nor easily possible IMHO).
