### PR TITLE
Codefresh support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Repo tokens are **not** required for public repos on Travis-Ci, CircleCI, or App
 | [Bitrise CI](https://www.bitrise.io/) |
 | [Buildkite CI](https://buildkite.com/) |
 | [CodeBuild CI](https://aws.amazon.com/codebuild/) |
+| [Codefresh CI](https://codefresh.io/) |
 | [CodePipeline](https://aws.amazon.com/codepipeline/) |
 | [Circle CI](https://circleci.com/) |
 | [Codeship CI](https://codeship.com/) |

--- a/lib/codecov/uploader.rb
+++ b/lib/codecov/uploader.rb
@@ -18,6 +18,7 @@ class Codecov::Uploader
     BUILDKITE = 'Buildkite CI',
     CIRCLE = 'Circle CI',
     CODEBUILD = 'Codebuild CI',
+    CODEFRESH = 'Codefresh CI',
     CODESHIP = 'Codeship CI',
     DRONEIO = 'Drone CI',
     GITHUB = 'GitHub Actions',
@@ -79,6 +80,8 @@ class Codecov::Uploader
            CIRCLE
          elsif ENV['CODEBUILD_CI'] == 'true'
            CODEBUILD
+         elsif (ENV['CI'] == 'true') && !ENV['CF_URL'].nil?
+           CODEFRESH
          elsif (ENV['CI'] == 'true') && (ENV['CI_NAME'] == 'codeship')
            CODESHIP
          elsif ((ENV['CI'] == 'true') || (ENV['CI'] == 'drone')) && (ENV['DRONE'] == 'true')
@@ -203,6 +206,15 @@ class Codecov::Uploader
                       matched.nil? ? ENV['CODEBUILD_SOURCE_VERSION'] : matched['pr']
                     end
       params[:build_url] = ENV['CODEBUILD_BUILD_URL']
+    when CODEFRESH
+      # https://codefresh.io/docs/docs/codefresh-yaml/variables/
+      params[:service] = 'codefresh'
+      params[:branch] = ENV['CF_BRANCH']
+      params[:build] = ENV['CF_BUILD_ID']
+      params[:build_url] = ENV['CF_BUILD_URL']
+      params[:commit] = ENV['CF_REVISION']
+      params[:pr] = ENV['CF_PULL_REQUEST_NUMBER']
+      params[:slug] = ENV['CF_REPO_OWNER'] + '/' + ENV['CF_REPO_NAME']
     when CODESHIP
       # https://www.codeship.io/documentation/continuous-integration/set-environment-variables/
       params[:service] = 'codeship'

--- a/lib/codecov/uploader.rb
+++ b/lib/codecov/uploader.rb
@@ -208,7 +208,7 @@ class Codecov::Uploader
       params[:build_url] = ENV['CODEBUILD_BUILD_URL']
     when CODEFRESH
       # https://codefresh.io/docs/docs/codefresh-yaml/variables/
-      params[:service] = 'codefresh'
+      # params[:service] = 'codefresh'
       params[:branch] = ENV['CF_BRANCH']
       params[:build] = ENV['CF_BUILD_ID']
       params[:build_url] = ENV['CF_BUILD_URL']

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -712,7 +712,7 @@ class TestCodecov < Minitest::Test
 
     result = upload
 
-    assert_equal('codefresh', result['params'][:service])
+    # assert_equal('codefresh', result['params'][:service])
     assert_equal('d653b934ed59c1a785cc1cc79d08c9aaa4eba73b', result['params'][:commit])
     assert_equal('458dq3q8-7354-4513-8702-ea7b9c81efb3', result['params'][:build])
     assert_equal('owner/repo', result['params'][:slug])

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -145,6 +145,14 @@ class TestCodecov < Minitest::Test
     ENV['BUILDKITE_BUILD_URL'] = nil
     ENV['BUILDKITE_PROJECT_SLUG'] = nil
     ENV['BUILDKITE_COMMIT'] = nil
+    ENV['CF_BRANCH'] = nil
+    ENV['CF_BUILD_ID'] = nil
+    ENV['CF_BUILD_URL'] = nil
+    ENV['CF_PULL_REQUEST_NUMBER'] = nil
+    ENV['CF_REPO_NAME'] = nil
+    ENV['CF_REPO_OWNER'] = nil
+    ENV['CF_REVISION'] = nil
+    ENV['CF_URL'] = nil
     ENV['CI'] = 'true'
     ENV['CI_BRANCH'] = nil
     ENV['CI_BUILD_ID'] = nil
@@ -688,6 +696,29 @@ class TestCodecov < Minitest::Test
     assert_equal('owner/repo', result['params'][:slug])
     assert_equal('master', result['params'][:branch])
     assert_equal('git-commit-hash-12345', result['params'][:pr])
+    assert_equal('f881216b-b5c0-4eb1-8f21-b51887d1d506', result['params']['token'])
+  end
+
+  def test_codefresh
+    ENV['CF_URL'] = 'https://g.codefresh.io'
+    ENV['CF_BUILD_ID'] = '458dq3q8-7354-4513-8702-ea7b9c81efb3'
+    ENV['CF_BUILD_URL'] = 'https://g.codefresh.io/build/458dq3q8-7354-4513-8702-ea7b9c81efb3'
+    ENV['CF_REVISION'] = 'd653b934ed59c1a785cc1cc79d08c9aaa4eba73b'
+    ENV['CF_BRANCH'] = 'master'
+    ENV['CF_PULL_REQUEST_NUMBER'] = '123'
+    ENV['CF_REPO_OWNER'] = 'owner'
+    ENV['CF_REPO_NAME'] = 'repo'
+    ENV['CODECOV_TOKEN'] = 'f881216b-b5c0-4eb1-8f21-b51887d1d506'
+
+    result = upload
+
+    assert_equal('codefresh', result['params'][:service])
+    assert_equal('d653b934ed59c1a785cc1cc79d08c9aaa4eba73b', result['params'][:commit])
+    assert_equal('458dq3q8-7354-4513-8702-ea7b9c81efb3', result['params'][:build])
+    assert_equal('owner/repo', result['params'][:slug])
+    assert_equal('master', result['params'][:branch])
+    assert_equal('123', result['params'][:pr])
+    assert_equal('https://g.codefresh.io/build/458dq3q8-7354-4513-8702-ea7b9c81efb3', result['params'][:build_url])
     assert_equal('f881216b-b5c0-4eb1-8f21-b51887d1d506', result['params']['token'])
   end
 

--- a/test/test_codecov.rb
+++ b/test/test_codecov.rb
@@ -700,6 +700,7 @@ class TestCodecov < Minitest::Test
   end
 
   def test_codefresh
+    ENV['CI'] = 'true'
     ENV['CF_URL'] = 'https://g.codefresh.io'
     ENV['CF_BUILD_ID'] = '458dq3q8-7354-4513-8702-ea7b9c81efb3'
     ENV['CF_BUILD_URL'] = 'https://g.codefresh.io/build/458dq3q8-7354-4513-8702-ea7b9c81efb3'


### PR DESCRIPTION
This adds codefresh support: https://codefresh.io/

Environment variables: https://codefresh.io/docs/docs/codefresh-yaml/variables/

I've verified that it works for our private repo.

Note: Doesn't currently work with `codefresh` as a service name. Does that require changes on the codecov API?