### PR TITLE
Relax the version constraint to support simplecov 0.22

### DIFF
--- a/codecov.gemspec
+++ b/codecov.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.platform              = Gem::Platform::RUBY
   s.required_ruby_version = '>= 2.4', '< 4'
 
-  s.add_dependency 'simplecov', '>= 0.15', '< 0.22'
+  s.add_dependency 'simplecov', '>= 0.15', '< 0.23'
 
   s.add_development_dependency 'minitest', '~> 5.0'
   s.add_development_dependency 'mocha', '~> 1.0'


### PR DESCRIPTION
simplecov 0.22 has been [released](https://github.com/simplecov-ruby/simplecov/blob/main/CHANGELOG.md#0220-2022-12-23) and this gem needs to support it.

Currently, updating simplecov 0.22 requires codecov to go back to 0.2.12 which happened to have no upper bound in the version constraint.  Here's a hunk of Gemfile.lock included in the PR I received from dependabot.

```patch
-    codecov (0.6.0)
-      simplecov (>= 0.15, < 0.22)
+    codecov (0.2.12)
+      json
+      simplecov
```

Then codecov 0.2.12 failed to upload coverage data with the configuration that works with 0.6.0. (Bad URI error)